### PR TITLE
fix: Update URLs

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -18,11 +18,11 @@
             <div class="text-center hero-content mx-auto">
                 <h1 class="text-white center mb-4 margin="4 px">{{ page.title }}</h1>
                 <p class="mx-auto text-white">
-                    <a href="{{ site.url }}" class="text-white">Home</a>
+                    <a href="{{ '/' | relative_url }}" class="text-white">Home</a>
                     /
-                    <a href="{{ absolute_url }}/blog" class="text-white">Blog</a>
+                    <a href="{{ '/blog' | relative_url }}" class="text-white">Blog</a>
                     /
-                    <a href="{{ realtive_url }}" class="text-white">{{ page.title }}</a>
+                    <a href="{{ page.url | relative_url }}" class="text-white">{{ page.title }}</a>
                 </p>
             </div>
         </section>


### PR DESCRIPTION
Theres a typo in the original relative 

You need to send a path string to the absolute and relative filters.

The only time you need absolute url is for robots and sitemap. Using relative URL is the way to go on Jekyll sites.

The URL will become "/blog" and if you right click and copy the link or hover over it, you'll get foo.github.io/blog

Relative url will also allow you to do foo.github.io/repo-name/blog and all urls will start with /repo-name which isn't so important here but a good habit across jekyll sites.